### PR TITLE
Support for "q.op" parameter

### DIFF
--- a/solr/core.py
+++ b/solr/core.py
@@ -725,7 +725,7 @@ class SearchHandler(object):
         self.arg_separator = arg_separator
 
     def __call__(self, q=None, fields=None, highlight=None,
-                 score=True, sort=None, sort_order="asc", **params):
+                 score=True, sort=None, sort_order="asc", op=None, **params):
         """
         q is the query string.
 
@@ -778,6 +778,9 @@ class SearchHandler(object):
 
         if q is not None:
             params['q'] = q
+
+        if op is not None:
+            params['q.op'] = op
 
         if fields:
             if not isinstance(fields, basestring):


### PR DESCRIPTION
Starting from Solr 7.0 this parameter is very essential as `defaultOperator` was dropped from the schema. Because of the dot in the name, it is not easy and straightforward to specify it in solrpy using kwargs. So, let's support it natively.