### PR TITLE
Support specifying SSL certificate

### DIFF
--- a/solr/async_solr.py
+++ b/solr/async_solr.py
@@ -53,7 +53,8 @@ class AsyncSolr:
                  response_format: str = 'json',
                  auth_token: str | None = None,
                  auth: Any = None,
-                 debug: bool = False) -> None:
+                 debug: bool = False,
+                 verify: bool | str | None = None) -> None:
         """Create an async Solr connection.
 
         Same parameters as :class:`~solr.core.Solr`.
@@ -71,6 +72,9 @@ class AsyncSolr:
         :param auth_token: Bearer token string for authentication.
         :param auth: Callable returning a ``dict[str, str]`` of auth headers per request.
         :param debug: Log all requests and responses.
+        :param verify: SSL certificate verification. Pass ``False`` to disable,
+            or a path string to a CA bundle or certificate file. Passed directly
+            to ``httpx.AsyncClient(verify=...)``. Defaults to httpx's default (``True``).
         """
         self.scheme, self.host, self.path = urlparse.urlparse(url, 'http')[:3]
         self.url = url
@@ -107,9 +111,14 @@ class AsyncSolr:
         else:
             self.auth_headers = {}
 
+        self._verify = verify
         base_url = '%s://%s' % (self.scheme, self.host)
-        self._client: httpx.AsyncClient = httpx.AsyncClient(
-            base_url=base_url, timeout=self.timeout, follow_redirects=True)
+        client_kwargs: dict[str, Any] = {
+            'base_url': base_url, 'timeout': self.timeout, 'follow_redirects': True,
+        }
+        if verify is not None:
+            client_kwargs['verify'] = verify
+        self._client: httpx.AsyncClient = httpx.AsyncClient(**client_kwargs)
 
         self._server_version: tuple[int, ...] | None = None
 
@@ -127,7 +136,10 @@ class AsyncSolr:
     def _detect_version_sync(self) -> tuple[int, ...]:
         """Detect Solr version synchronously (used during __init__)."""
         base_url = '%s://%s' % (self.scheme, self.host)
-        with httpx.Client(base_url=base_url, timeout=self.timeout) as client:
+        client_kwargs: dict[str, Any] = {'base_url': base_url, 'timeout': self.timeout}
+        if self._verify is not None:
+            client_kwargs['verify'] = self._verify
+        with httpx.Client(**client_kwargs) as client:
             base_paths = [self.path]
             parent = self.path.rsplit('/', 1)[0]
             if parent and parent != self.path:

--- a/solr/core.py
+++ b/solr/core.py
@@ -53,7 +53,8 @@ class Solr:
                  response_format: str = 'json',
                  auth_token: str | None = None,
                  auth: Any = None,
-                 debug: bool = False) -> None:
+                 debug: bool = False,
+                 verify: bool | str | None = None) -> None:
         """
         Connect to the Solr instance at *url*.
 
@@ -74,6 +75,9 @@ class Solr:
         :param auth_token: Bearer token string for authentication.
         :param auth: Callable returning a ``dict[str, str]`` of auth headers per request.
         :param debug: Log all requests and responses.
+        :param verify: SSL certificate verification. Pass ``False`` to disable,
+            or a path string to a CA bundle or certificate file. Passed directly
+            to ``httpx.Client(verify=...)``. Defaults to httpx's default (``True``).
         """
 
         self.scheme, self.host, self.path = urllib.urlparse(url, 'http')[:3]
@@ -114,6 +118,8 @@ class Solr:
             if ssl_key and not ssl_cert:
                 raise ValueError("ssl_cert is required when ssl_key is provided")
             self._client_kwargs['cert'] = (ssl_cert, ssl_key) if ssl_key else ssl_cert
+        if verify is not None:
+            self._client_kwargs['verify'] = verify
         self.__client: httpx.Client | None = None
 
         self.response_version = 2.2

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -76,7 +76,6 @@ class TestVerifyParam(unittest.TestCase):
     def test_verify_path_in_client_kwargs(self):
         conn = solr.Solr(SOLR_HTTP, verify='/path/to/ca-bundle.crt')
         self.assertEqual(conn._client_kwargs['verify'], '/path/to/ca-bundle.crt')
-        conn.close()
 
     def test_verify_false_passed_to_httpx_client(self):
         import httpx
@@ -93,7 +92,9 @@ class TestVerifyParam(unittest.TestCase):
         self.assertFalse(conn._verify)
 
     def test_async_verify_path(self):
-        conn = AsyncSolr(SOLR_HTTP, verify='/path/to/ca.pem')
+        from unittest.mock import patch
+        with patch('httpx.AsyncClient'):
+            conn = AsyncSolr(SOLR_HTTP, verify='/path/to/ca.pem')
         self.assertEqual(conn._verify, '/path/to/ca.pem')
 
 

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -2,6 +2,7 @@
 
 import unittest
 import solr
+from solr.async_solr import AsyncSolr
 from tests.conftest import SOLR_HTTP, SolrConnectionTestCase
 
 
@@ -58,6 +59,42 @@ class TestHttpxClient(unittest.TestCase):
         self.assertIsInstance(conn.server_version, tuple)
         self.assertGreaterEqual(len(conn.server_version), 2)
         conn.close()
+
+
+class TestVerifyParam(unittest.TestCase):
+
+    def test_verify_default_absent_from_client_kwargs(self):
+        conn = solr.Solr(SOLR_HTTP)
+        self.assertNotIn('verify', conn._client_kwargs)
+        conn.close()
+
+    def test_verify_false_in_client_kwargs(self):
+        conn = solr.Solr(SOLR_HTTP, verify=False)
+        self.assertIs(conn._client_kwargs['verify'], False)
+        conn.close()
+
+    def test_verify_path_in_client_kwargs(self):
+        conn = solr.Solr(SOLR_HTTP, verify='/path/to/ca-bundle.crt')
+        self.assertEqual(conn._client_kwargs['verify'], '/path/to/ca-bundle.crt')
+        conn.close()
+
+    def test_verify_false_passed_to_httpx_client(self):
+        import httpx
+        conn = solr.Solr(SOLR_HTTP, verify=False)
+        self.assertIsInstance(conn._client, httpx.Client)
+        conn.close()
+
+    def test_async_verify_default_is_none(self):
+        conn = AsyncSolr(SOLR_HTTP)
+        self.assertIsNone(conn._verify)
+
+    def test_async_verify_false(self):
+        conn = AsyncSolr(SOLR_HTTP, verify=False)
+        self.assertFalse(conn._verify)
+
+    def test_async_verify_path(self):
+        conn = AsyncSolr(SOLR_HTTP, verify='/path/to/ca.pem')
+        self.assertEqual(conn._verify, '/path/to/ca.pem')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allow using a path to self signed cert, or skip SSL verification completely.

Resolves https://github.com/search5/solrpy/issues/39