### PR TITLE
Support specifying Solr version

### DIFF
--- a/solr/async_solr.py
+++ b/solr/async_solr.py
@@ -53,7 +53,8 @@ class AsyncSolr:
                  response_format: str = 'json',
                  auth_token: str | None = None,
                  auth: Any = None,
-                 debug: bool = False) -> None:
+                 debug: bool = False,
+                 solr_version: tuple[int, ...] | None = None) -> None:
         """Create an async Solr connection.
 
         Same parameters as :class:`~solr.core.Solr`.
@@ -71,6 +72,8 @@ class AsyncSolr:
         :param auth_token: Bearer token string for authentication.
         :param auth: Callable returning a ``dict[str, str]`` of auth headers per request.
         :param debug: Log all requests and responses.
+        :param solr_version: Override the detected Solr version, e.g. ``(9, 4, 1)``.
+            Skips autodetection entirely.
         """
         self.scheme, self.host, self.path = urlparse.urlparse(url, 'http')[:3]
         self.url = url
@@ -111,7 +114,7 @@ class AsyncSolr:
         self._client: httpx.AsyncClient = httpx.AsyncClient(
             base_url=base_url, timeout=self.timeout, follow_redirects=True)
 
-        self._server_version: tuple[int, ...] | None = None
+        self._server_version: tuple[int, ...] | None = solr_version
 
     @property
     def server_version(self) -> tuple[int, ...]:

--- a/solr/core.py
+++ b/solr/core.py
@@ -53,7 +53,8 @@ class Solr:
                  response_format: str = 'json',
                  auth_token: str | None = None,
                  auth: Any = None,
-                 debug: bool = False) -> None:
+                 debug: bool = False,
+                 solr_version: tuple[int, ...] | None = None) -> None:
         """
         Connect to the Solr instance at *url*.
 
@@ -74,6 +75,8 @@ class Solr:
         :param auth_token: Bearer token string for authentication.
         :param auth: Callable returning a ``dict[str, str]`` of auth headers per request.
         :param debug: Log all requests and responses.
+        :param solr_version: Override the detected Solr version, e.g. ``(9, 4, 1)``.
+            Skips autodetection entirely.
         """
 
         self.scheme, self.host, self.path = urllib.urlparse(url, 'http')[:3]
@@ -158,7 +161,7 @@ class Solr:
         self.always_commit = always_commit
         self.debug = debug
         self.select = SearchHandler(self, "/select")
-        self._server_version: tuple[int, ...] | None = None
+        self._server_version: tuple[int, ...] | None = solr_version
 
     @property
     def _client(self) -> httpx.Client:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -165,3 +165,17 @@ class TestSolrConnectionRemoved(unittest.TestCase):
 # 1.0.3 tests — response_format
 # ===================================================================
 
+
+class TestSolrVersionOverride(unittest.TestCase):
+
+    def test_version_override_skips_autodetect(self):
+        conn = solr.Solr(SOLR_HTTP, solr_version=(9, 4, 1))
+        self.assertEqual(conn.server_version, (9, 4, 1))
+        conn.close()
+
+    def test_async_version_override(self):
+        from solr.async_solr import AsyncSolr
+        conn = AsyncSolr(SOLR_HTTP, solr_version=(9, 4, 1))
+        self.assertEqual(conn.server_version, (9, 4, 1))
+
+


### PR DESCRIPTION
In some distributions of Solr (e.g DSE) the solr-spec-version returned in the /admin/info/system response is null. In these cases, it is useful to have the ability for specifying the known Solr version.